### PR TITLE
Add support for other FM 3180 SKU

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-questone2.init
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-questone2.init
@@ -34,7 +34,7 @@ start)
         hwsku=$(decode-syseeprom | grep "Label" | awk '{print $5 $6}')
         platform_path="/usr/share/sonic/device/x86_64-cel_questone_2-r0/"
         if [ x$hwsku = x"Questone-II" ] || [ x$hwsku = x"ArcticaNX4808xxv" ] || \
-           [ x$hwsku = x"R1N25A" ]; then
+           [ x$hwsku = x"R1N25A" ] || [ x$hwsku = x"R1N26A" ]; then
             echo "Questone_2 t1" > $hwsku_file
             cp ${platform_path}/Questone_2/platform_components.json $platform_path
             cp ${platform_path}/Questone_2/custom_led.bin $platform_path


### PR DESCRIPTION
Add support for FM 3180 Reverse Airflow SKU.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

